### PR TITLE
Fix artifact-attestations-step-for-container-images.md - yaml syntax

### DIFF
--- a/data/reusables/actions/artifact-attestations-step-for-container-images.md
+++ b/data/reusables/actions/artifact-attestations-step-for-container-images.md
@@ -1,4 +1,4 @@
-* name: Generate artifact attestation
+- name: Generate artifact attestation
   uses: actions/attest-build-provenance@v1
   with:
     subject-name: {% raw %}${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}{% endraw %}


### PR DESCRIPTION
artifact-attestations-step-for-container-images has a markdown ending. However, it is yaml snipped and should, therefore, not have an asterisk.

The bug was introduced in https://github.com/github/docs/commit/0886a399f07aedae418d587873ffc6c0810ae7eb

and breaks the sample: https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-docker-hub-and-github-packages

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Fix the yaml syntax.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
